### PR TITLE
Fix bug in qa4sm test integration 

### DIFF
--- a/src/qa4sm_reader/plotter.py
+++ b/src/qa4sm_reader/plotter.py
@@ -453,7 +453,7 @@ class QA4SMPlotter():
         # put all Variables in the same dataframe
         values = pd.concat(values)
         # values are all Nan or NaNf - not plotted
-        if df.isnull().values.all():
+        if np.isnan(values.to_numpy()).all():
             return None
         # create plot
         fig, ax = self._boxplot_definition(
@@ -540,7 +540,7 @@ class QA4SMPlotter():
             dfs, Var = values
             df = pd.concat(dfs)
             # values are all Nan or NaNf - not plotted
-            if df.isnull().values.all():
+            if np.isnan(df.to_numpy()).all():
                 continue
             # necessary if statement to prevent key error when no CIs are in the netCDF
             if ci:
@@ -663,7 +663,7 @@ class QA4SMPlotter():
         """
         fnames = []
         for Var in self.img._iter_vars(**{'metric':metric}):
-            if not (Var.values.isnull().values.all() or Var.is_CI):
+            if not (np.isnan(Var.values.to_numpy()).all() or Var.is_CI):
                 fns = self.mapplot_var(Var,
                                        out_name=None,
                                        out_types=out_types,


### PR DESCRIPTION
This bug was caused by an inconsistency between the output of `pd.isnull()`, used previously here, and `np.isnan()`, used in the qa4sm tests. This is because 0. was considered nan by the `isnull` function.