### PR TITLE
Update of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ seaborn>=0.9.0
 cartopy>=0.17.0
 colorcet>=2.0.1
 python>=3.7
+setuptools>=58.0


### PR DESCRIPTION
Set requirement `setuptools>=58.0` to overcome conflict with pypi upload