### PR TITLE
Raise exception if no data can be plotted

### DIFF
--- a/src/qa4sm_reader/plotter.py
+++ b/src/qa4sm_reader/plotter.py
@@ -909,6 +909,9 @@ class QA4SMPlotter:
                                                     mean_ci=False):
             values.append(data)
 
+        if not values:
+            raise PlotterError(f"No valid values for {metric}")
+            
         values = pd.concat(values, axis=1)
         # override values from metric
         if df is not None:
@@ -960,6 +963,8 @@ class QA4SMPlotter:
                                               stats=False,
                                               mean_ci=False):
             values.append(df)
+        if not values:
+            raise PlotterError(f"No valid values for {metric}")
         values = pd.concat(values, axis=1)
 
         metric_name = globals._metric_name[metric]


### PR DESCRIPTION
I'm currently trying to get a run done in my local setup where all validations fail due to a too low amount of data. Locally I adapted QA4SM to also generate graphs in this case. This leads to only NaNs in the result. This leads to an error here:

https://github.com/awst-austria/qa4sm-reader/blob/583a084392870b81d730523ae27a2bf266e115f0/src/qa4sm_reader/plotter.py#L906-L912

Concatenating fails, because _yield_values does not return anything, and `values` stays an empty list.

https://github.com/awst-austria/qa4sm-reader/blob/583a084392870b81d730523ae27a2bf266e115f0/src/qa4sm_reader/plotter.py#L366

As a result, the only plot that is generated is the one for #observations. Raising the proper error here will make it possible for the plotter to handle this error, and consequentially we would also get the error code plots.