### PR TITLE
Fix meta plots sometimes not created

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: conda-incubator/setup-miniconda@v2.0.1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
           environment-file: environment.yml
           activate-environment: qa4sm_reader # todo: must match with name in environment.yml
           auto-activate-base: false

--- a/src/qa4sm_reader/globals.py
+++ b/src/qa4sm_reader/globals.py
@@ -521,6 +521,9 @@ def get_resolution_info(dataset, raise_error=False):
 # =====================================================
 # information needed for plotting the metadata-boxplots
 
+# Min number of samples per bin to create a boxplot:
+meta_boxplot_min_samples = 5
+
 lc_classes = {
     "unknown": "Not provided",
     0: 'Other',
@@ -630,6 +633,7 @@ metadata = {
     # --- FRM4SM QI, not always present
     "frm_class": ("FRM Classification", None, "discrete", None)
 }
+
 
 soil_types = ["clay_fraction", "silt_fraction", "sand_fraction"]
 instrument_depths = ["instrument_depthfrom", "instrument_depthto"]

--- a/src/qa4sm_reader/plot_all.py
+++ b/src/qa4sm_reader/plot_all.py
@@ -41,7 +41,8 @@ def plot_all(filepath: str,
         for each metric, metadata plots are provided
         (see plotter.QA4SMPlotter.plot_save_metadata)
         - 'never' or False: No metadata plots are created
-        - 'always': Metadata plots are always for all metrics
+        - 'always': Metadata plots are always created for all metrics
+                   (set the meta_boxplot_min_size to 0)
         - 'threshold' or True: Metadata plots are only created if the number
                                of points is above the `meta_boxplot_min_size`
                                threshold from globals.py. Otherwise a warning

--- a/src/qa4sm_reader/plot_all.py
+++ b/src/qa4sm_reader/plot_all.py
@@ -151,9 +151,3 @@ def get_img_stats(
     return table
 
 
-if __name__ == '__main__':
-    import tempfile
-    with tempfile.TemporaryDirectory() as path_out:
-        path_in = "/tmp/0-ISMN.soil_moisture_with_1-C3S_combined.sm.nc"
-        plot_all(path_in, out_dir='/tmp/plots', save_metadata=True)
-

--- a/src/qa4sm_reader/plot_all.py
+++ b/src/qa4sm_reader/plot_all.py
@@ -68,6 +68,12 @@ def plot_all(filepath: str,
             save_metadata = 'threshold'
     save_metadata = save_metadata.lower()
 
+    _options = ['never', 'always', 'threshold']
+    if save_metadata not in _options:
+        raise ValueError(f"save_metadata must be one of: "
+                         f"{', '.join(_options)} "
+                         f"but `{save_metadata}` was passed.")
+
     # initialise image and plotter
     fnames_bplot, fnames_mapplot, fnames_csv = [], [], []
     periods = extract_periods(filepath)

--- a/src/qa4sm_reader/plot_all.py
+++ b/src/qa4sm_reader/plot_all.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
 import warnings
+from typing import Union
 
 import pandas as pd
 from qa4sm_reader.plotter import QA4SMPlotter
 from qa4sm_reader.img import QA4SMImg, extract_periods
-from qa4sm_reader.exceptions import PlotterError
+import qa4sm_reader.globals as globals
 
 
 def plot_all(filepath: str,
@@ -14,7 +15,7 @@ def plot_all(filepath: str,
              out_dir: str = None,
              out_type: str = 'png',
              save_all: bool = True,
-             save_metadata: bool = False,
+             save_metadata: Union[str, bool] = 'never',
              save_csv: bool = True,
              engine: str = 'h5netcdf',
              **plotting_kwargs) -> tuple:
@@ -34,10 +35,17 @@ def plot_all(filepath: str,
         Path to output generated plot. If None, defaults to the current working directory.
     out_type: str or list
         extensions which the files should be saved in
-    save_all: bool, optional. Default is True.
+    save_all: bool, optional (default: True)
         all plotted images are saved to the output directory
-    save_metadata: bool, optional. Default is False.
-        for each metric, 3 metadata plots are provided (see plotter.QA4SMPlotter.plot_save_metadata)
+    save_metadata: str or bool, optional (default: 'never')
+        for each metric, metadata plots are provided
+        (see plotter.QA4SMPlotter.plot_save_metadata)
+        - 'never' or False: No metadata plots are created
+        - 'always': Metadata plots are always for all metrics
+        - 'threshold' or True: Metadata plots are only created if the number
+                               of points is above the `meta_boxplot_min_size`
+                               threshold from globals.py. Otherwise a warning
+                               is printed.
     save_csv: bool, optional. Default is True.
         save a .csv file with the validation statistics
     engine: str, optional (default: h5netcdf)
@@ -52,6 +60,13 @@ def plot_all(filepath: str,
         lists of filenames for created mapplots and boxplots
     fnames_csv: list
     """
+    if isinstance(save_metadata, bool):
+        if not save_metadata:
+            save_metadata = 'never'
+        else:
+            save_metadata = 'threshold'
+    save_metadata = save_metadata.lower()
+
     # initialise image and plotter
     fnames_bplot, fnames_mapplot, fnames_csv = [], [], []
     periods = extract_periods(filepath)
@@ -82,17 +97,23 @@ def plot_all(filepath: str,
                 fnames_bplot.extend(metric_bplots)
             if metric_mapplots:
                 fnames_mapplot.extend(metric_mapplots)
-            if img.metadata and save_metadata:
+            if img.metadata and (save_metadata != 'never'):
                 try:
+                    if save_metadata == 'always':
+                        kwargs = {
+                            'meta_boxplot_min_samples': 0
+                        }
+                    else:
+                        kwargs = {
+                            'meta_boxplot_min_samples': globals.meta_boxplot_min_samples
+                        }
+
                     fnames_bplot.extend(
                         plotter.plot_save_metadata(
                             metric,
                             out_types=out_type,
+                            **kwargs
                         ))
-                except PlotterError:
-                    warnings.warn(
-                        "Too few points are available to generate metadata-based plots"
-                    )
                 except AttributeError as e:
                     warnings.warn(
                         f"Error when trying to plot_all for triple collocation nc files. \nIssue: #59 {e}"
@@ -128,3 +149,11 @@ def get_img_stats(
     table = img.stats_df()
 
     return table
+
+
+if __name__ == '__main__':
+    import tempfile
+    with tempfile.TemporaryDirectory() as path_out:
+        path_in = "/tmp/0-ISMN.soil_moisture_with_1-C3S_combined.sm.nc"
+        plot_all(path_in, out_dir='/tmp/plots', save_metadata=True)
+

--- a/src/qa4sm_reader/plotting_methods.py
+++ b/src/qa4sm_reader/plotting_methods.py
@@ -903,7 +903,8 @@ def bin_continuous(
     sorted = np.sort(meta_range)
     if len(meta_range) < min_size:
         raise ValueError(
-            "There are too few points per metadata to generate the boxplots. You can set 'min_size'"
+            "There are too few points per metadata to generate the boxplots. "
+            f"You can set 'min_size' (now at {min_size})"
             "to a lower value to allow for smaller samples.")
     bin_values, unique_values, bin_size = resize_bins(sorted, nbins)
     # adjust bins to have the specified number of bins if possible, otherwise enough valoues per bin
@@ -1334,6 +1335,7 @@ def boxplot_metadata(
     nbins=4,
     axis=None,
     plot_type: str = "catplot",
+    meta_boxplot_min_samples=5,
     **bplot_kwargs,
 ) -> tuple:
     """
@@ -1360,6 +1362,9 @@ def boxplot_metadata(
     plot_type : str, default is 'catplot'
         one of 'catplot' or 'multiplot', defines the type of plots for the 'classes' and 'continuous'
         metadata types
+    meta_boxplot_min_samples: int, optional (default: 5)
+        Minimum number of points in a bin to be plotted.
+        If not enough points are available, the plot is not created.
 
     Returns
     -------
@@ -1379,6 +1384,7 @@ def boxplot_metadata(
         metadata_values=metadata_values,
         meta_key=meta_key,
         nbins=nbins,
+        min_size=meta_boxplot_min_samples,
     )
     if to_plot is None:
         raise PlotterError(


### PR DESCRIPTION
Fix bug where no more metadata plots were created as soon as one of them failed (e.g. soil type failing led to FRM class plot not being created).
Also add settings to `globals.py` to control the number of points necessary in a bin to create a box plot (default 5)
Also change `save_metadata` options of `plot_all()` as described in issue -> Fix #58 