### PR TITLE
fixed failing windows miniconda setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
               run: |
                   mkdir -p artifacts
                   filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export --no-builds > artifacts/$filename
+                  micromamba env export > artifacts/$filename
 
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
         - cron: '0 0 * * *' # daily
 
 jobs:
-    build:
+    linux-tests:
         name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
         runs-on: ${{ matrix.os }}
         strategy:
@@ -19,11 +19,6 @@ jobs:
                 python-version: ['3.8', '3.9', '3.10']
                 os: ['ubuntu-latest']
                 ymlfile: ['environment.yml']
-                include:
-                    - os: 'windows-latest'
-                      python-version: '3.10'
-                      ymlfile: 'environment.yml'
-
         steps:
             - uses: actions/checkout@v2
               with:
@@ -39,13 +34,13 @@ jobs:
               shell: bash -l {0}
               run: |
                   micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
-                  micromamba create -y --name qa4sm_reader python=${{ matrix.python-version }}  # Explicitly create the environment if not already created
                   echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
 
-            - name: Activate environment
+            - name: Create and activate environment
               shell: bash -l {0}
               run: |
                   source ~/micromamba/etc/profile.d/micromamba.sh
+                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                   micromamba activate qa4sm_reader
 
             - name: Print environment infos
@@ -85,9 +80,77 @@ jobs:
                   COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
                   COVERALLS_PARALLEL: true
 
+    windows-tests:
+        name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                python-version: ['3.10']
+                os: ['windows-latest']
+                ymlfile: ['environment.yml']
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - uses: mamba-org/setup-micromamba@v1
+              with:
+                  micromamba-version: 'latest'
+                  environment-file: ${{ matrix.ymlfile }} # Ensure the env file is correctly defined
+                  micromamba-root-path: ~/micromamba # Optional, where to install micromamba
+
+            - name: Initialize micromamba environment
+              shell: cmd
+              run: |
+                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
+
+            - name: Create and activate environment
+              shell: cmd
+              run: |
+                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
+                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
+                  micromamba activate qa4sm_reader
+
+            - name: Print environment infos
+              shell: cmd
+              run: |
+                  micromamba info
+                  micromamba list
+                  pip list
+                  where pip
+                  where python
+
+            - name: Export Environment
+              shell: cmd
+              run: |
+                  mkdir artifacts
+                  set filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
+                  micromamba env export --name qa4sm_reader > artifacts\%filename%
+
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
+                  path: artifacts\*
+
+            - name: Install package and test
+              shell: cmd
+              run: |
+                  pip install -e .
+                  pytest
+
+            - name: Upload Coverage
+              shell: cmd
+              run: |
+                  pip install coveralls && coveralls --service=github
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                  COVERALLS_PARALLEL: true
+
     coveralls:
         name: Submit Coveralls 👚
-        needs: build
+        needs: [linux-tests, windows-tests]
         runs-on: ubuntu-latest
         container: python:3-slim
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # This workflow will install Python dependencies and run tests on
-# Windows and Linux systems with a variety of Python versions
+# windows and linux systems with a variety of Python versions
 
 # For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
@@ -30,70 +30,38 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   submodules: true
-
-            - uses: mamba-org/setup-micromamba@v1
+            - uses: conda-incubator/setup-miniconda@v3
               with:
-                  micromamba-version: 'latest'
+                  miniconda-version: 'latest'
+                  auto-update-conda: true
+                  python-version: ${{ matrix.python-version }}
                   environment-file: ${{ matrix.ymlfile }}
-                  micromamba-root-path: ~/micromamba
-
-            - name: Initialize micromamba environment
-              shell: bash -l {0}
-              run: |
-                  if [ "${{ runner.os }}" == "Linux" ]; then
-                    micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
-                    micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
-                    echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
-                  else
-                    echo "set PATH=%PATH%;%USERPROFILE%\micromamba\bin" >> $GITHUB_ENV
-                    micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
-                    micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
-                  fi
-
-            - name: Activate environment
-              shell: bash -l {0}
-              run: |
-                  if [ "${{ runner.os }}" == "Linux" ]; then
-                    source ~/micromamba/etc/profile.d/micromamba.sh
-                    micromamba activate qa4sm_reader
-                  else
-                    call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
-                    micromamba activate qa4sm_reader
-                  fi
-
+                  activate-environment: qa4sm_reader # todo: must match with name in environment.yml
+                  auto-activate-base: false
             - name: Print environment infos
               shell: bash -l {0}
               run: |
-                  micromamba info
-                  micromamba list
+                  conda info -a
+                  conda list
                   pip list
-                  if [ "${{ runner.os }}" == "Linux" ]; then
-                    which pip
-                    which python
-                  else
-                    where pip
-                    where python
-                  fi
-
+                  which pip
+                  which python
             - name: Export Environment
               shell: bash -l {0}
               run: |
                   mkdir -p artifacts
                   filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export --name qa4sm_reader > artifacts/$filename
-
+                  conda env export --no-builds | grep -v "prefix" > artifacts/$filename
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4
               with:
                   name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
                   path: artifacts/*
-
             - name: Install package and test
               shell: bash -l {0}
               run: |
                   pip install -e .
                   pytest
-
             - name: Upload Coverage
               shell: bash -l {0}
               run: |
@@ -102,7 +70,6 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
                   COVERALLS_PARALLEL: true
-
     coveralls:
         name: Submit Coveralls 👚
         needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # This workflow will install Python dependencies and run tests on
-# windows and linux systems with a variety of Python versions
+# Windows and Linux systems with a variety of Python versions
 
 # For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
@@ -7,78 +7,129 @@
 name: tests
 
 on:
-  push:
-  pull_request:
-  workflow_dispatch:
-  schedule: # only upstream, won't trigger on forks!
-    - cron: '0 0 * * *' # daily
+    push:
+    pull_request:
+    workflow_dispatch:
+    schedule: # only upstream, won't trigger on forks!
+        - cron: '0 0 * * *' # daily
 
 jobs:
-  build:
-    name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
-        os: ["ubuntu-latest"]
-        ymlfile: ["environment.yml"]
-        include:
-          - os: "windows-latest"
-            python-version: "3.10"
-            ymlfile: "environment.yml"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniconda-version: "latest"
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          environment-file: ${{ matrix.ymlfile }}
-          mamba-version: "*"
-          activate-environment: qa4sm_reader # todo: must match with name in environment.yml
-          auto-activate-base: false
-      - name: Print environment infos
-        shell: bash -l {0}
-        run: |
-          conda info -a
-          conda list
-          pip list
-          which pip
-          which python
-      - name: Export Environment
-        shell: bash -l {0}
-        run: |
-          mkdir -p artifacts
-          filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-          conda env export --no-builds | grep -v "prefix" > artifacts/$filename
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
-          path: artifacts/*
-      - name: Install package and test
-        shell: bash -l {0}
-        run: |
-          pip install -e .
-          pytest
-      - name: Upload Coverage
-        shell: bash -l {0}
-        run: |
-          pip install coveralls && coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-          COVERALLS_PARALLEL: true
-  coveralls:
-    name: Submit Coveralls 👚
-    needs: build
-    runs-on: ubuntu-latest
-    container: python:3-slim
-    steps:
-      - name: Finished
-        run: |
-          pip3 install --upgrade coveralls && coveralls --service=github --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    linux-tests:
+        name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                python-version: ['3.8', '3.9', '3.10']
+                os: ['ubuntu-latest']
+                ymlfile: ['environment.yml']
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: true
+            - uses: conda-incubator/setup-miniconda@v3
+              with:
+                  miniconda-version: 'latest'
+                  auto-update-conda: true
+                  python-version: ${{ matrix.python-version }}
+                  environment-file: ${{ matrix.ymlfile }}
+                  mamba-version: '*'
+                  activate-environment: qa4sm_reader # todo: must match with name in environment.yml
+                  auto-activate-base: false
+            - name: Print environment infos
+              shell: bash -l {0}
+              run: |
+                  conda info -a
+                  conda list
+                  pip list
+                  which pip
+                  which python
+            - name: Export Environment
+              shell: bash -l {0}
+              run: |
+                  mkdir -p artifacts
+                  filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
+                  conda env export --no-builds | grep -v "prefix" > artifacts/$filename
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
+                  path: artifacts/*
+            - name: Install package and test
+              shell: bash -l {0}
+              run: |
+                  pip install -e .
+                  pytest
+            - name: Upload Coverage
+              shell: bash -l {0}
+              run: |
+                  pip install coveralls && coveralls --service=github
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                  COVERALLS_PARALLEL: true
+
+    windows-tests:
+        name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                python-version: ['3.10']
+                os: ['windows-latest']
+                ymlfile: ['environment.yml']
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: true
+            - uses: conda-incubator/setup-miniconda@v3
+              with:
+                  miniconda-version: 'latest'
+                  auto-update-conda: true
+                  python-version: ${{ matrix.python-version }}
+                  environment-file: ${{ matrix.ymlfile }}
+                  activate-environment: qa4sm_reader # todo: must match with name in environment.yml
+                  auto-activate-base: false
+            - name: Print environment infos
+              shell: cmd
+              run: |
+                  conda info -a
+                  conda list
+                  pip list
+                  where pip
+                  where python
+            - name: Export Environment
+              shell: cmd
+              run: |
+                  mkdir artifacts
+                  set filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
+                  conda env export --no-builds | findstr /v "prefix" > artifacts/%filename%
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
+                  path: artifacts/*
+            - name: Install package and test
+              shell: cmd
+              run: |
+                  conda activate qa4sm_reader
+                  pip install -e .
+                  pytest
+            - name: Upload Coverage
+              shell: cmd
+              run: |
+                  pip install coveralls && coveralls --service=github
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                  COVERALLS_PARALLEL: true
+
+    coveralls:
+        name: Submit Coveralls 👚
+        needs: [linux-tests, windows-tests]
+        runs-on: ubuntu-latest
+        container: python:3-slim
+        steps:
+            - name: Finished
+              run: |
+                  pip3 install --upgrade coveralls && coveralls --service=github --finish
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,15 @@ jobs:
             - name: Initialize micromamba environment
               shell: bash -l {0}
               run: |
-                  source ~/micromamba/bin/micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
+                  micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
+                  micromamba create -y --name qa4sm_reader python=${{ matrix.python-version }}  # Explicitly create the environment if not already created
+                  echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
+
+            - name: Activate environment
+              shell: bash -l {0}
+              run: |
+                  source ~/micromamba/etc/profile.d/micromamba.sh
                   micromamba activate qa4sm_reader
-                  micromamba install python=${{ matrix.python-version }} -y
 
             - name: Print environment infos
               shell: bash -l {0}
@@ -56,7 +62,7 @@ jobs:
               run: |
                   mkdir -p artifacts
                   filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export > artifacts/$filename
+                  micromamba env export --name qa4sm_reader > artifacts/$filename
 
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
               run: |
                   mkdir -p artifacts
                   filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export --no-builds > artifacts/$filename
+                  micromamba env export > artifacts/$filename
 
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,12 @@ jobs:
         strategy:
             matrix:
                 python-version: ['3.8', '3.9', '3.10']
-                os: ['ubuntu-latest', 'windows-latest']
+                os: ['ubuntu-latest']
                 ymlfile: ['environment.yml']
+                include:
+                    - os: 'windows-latest'
+                      python-version: '3.10'
+                      ymlfile: 'environment.yml'
         steps:
             - uses: actions/checkout@v2
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 # This workflow will install Python dependencies and run tests on
 # windows and linux systems with a variety of Python versions
 
-# For more information see:
-# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: tests
 
 on:
@@ -35,11 +32,15 @@ jobs:
             - uses: mamba-org/setup-micromamba@v1
               with:
                   micromamba-version: 'latest'
-                  environment-file: ${{ matrix.ymlfile }}
-                  activate-environment: qa4sm_reader # Ensure this matches the name in your environment.yml
-                  python-version: ${{ matrix.python-version }}
-                  auto-activate-base: false
-                  extra-specs: 'python=${{ matrix.python-version }}'
+                  environment-file: ${{ matrix.ymlfile }} # Ensure the env file is correctly defined
+                  micromamba-root-path: ~/micromamba # Optional, where to install micromamba
+
+            - name: Initialize micromamba environment
+              shell: bash -l {0}
+              run: |
+                  source ~/micromamba/bin/micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
+                  micromamba activate qa4sm_reader
+                  micromamba install python=${{ matrix.python-version }} -y
 
             - name: Print environment infos
               shell: bash -l {0}
@@ -55,7 +56,7 @@ jobs:
               run: |
                   mkdir -p artifacts
                   filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export > artifacts/$filename
+                  micromamba env export --no-builds > artifacts/$filename
 
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,26 +96,26 @@ jobs:
             - name: Install Micromamba
               shell: cmd
               run: |
-                  curl -Ls https://micromamba.snakepit.net/api/micromamba/win-64/latest | tar -xvj -C %USERPROFILE%\micromamba\bin
-                  set PATH=%USERPROFILE%\micromamba\bin;%PATH%
+                  curl -Ls https://micromamba.snakepit.net/api/micromamba/win-64/latest | tar -xvj -C C:\micromamba\bin
+                  set PATH=C:\micromamba\bin;%PATH%
                   micromamba --version
 
             - uses: mamba-org/setup-micromamba@v1
               with:
                   micromamba-version: 'latest'
                   environment-file: ${{ matrix.ymlfile }}
-                  micromamba-root-path: %USERPROFILE%\micromamba
+                  micromamba-root-path: C:\micromamba
 
             - name: Initialize micromamba environment
               shell: cmd
               run: |
-                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
+                  micromamba shell init -s cmd -p C:\micromamba\envs\qa4sm_reader
 
             - name: Create and activate environment
               shell: cmd
               run: |
-                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
-                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
+                  call C:\micromamba\etc\profile.d\micromamba.cmd
+                  micromamba create -y --name qa4sm_reader --file C:\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
                   micromamba activate qa4sm_reader
 
             - name: Print environment infos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # This workflow will install Python dependencies and run tests on
-# Windows and Linux systems with a variety of Python versions
+# windows and linux systems with a variety of Python versions
 
 # For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
@@ -14,7 +14,7 @@ on:
         - cron: '0 0 * * *' # daily
 
 jobs:
-    linux-tests:
+    build:
         name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
         runs-on: ${{ matrix.os }}
         strategy:
@@ -22,99 +22,55 @@ jobs:
                 python-version: ['3.8', '3.9', '3.10']
                 os: ['ubuntu-latest']
                 ymlfile: ['environment.yml']
+                include:
+                    - os: 'windows-latest'
+                      python-version: '3.10'
+                      ymlfile: 'environment.yml'
+
         steps:
             - uses: actions/checkout@v2
               with:
                   submodules: true
-            - uses: conda-incubator/setup-miniconda@v3
+
+            - uses: mamba-org/setup-micromamba@v1
               with:
-                  miniconda-version: 'latest'
-                  auto-update-conda: true
-                  python-version: ${{ matrix.python-version }}
+                  micromamba-version: 'latest'
                   environment-file: ${{ matrix.ymlfile }}
-                  mamba-version: '*'
-                  activate-environment: qa4sm_reader # todo: must match with name in environment.yml
+                  activate-environment: qa4sm_reader # Ensure this matches the name in your environment.yml
+                  python-version: ${{ matrix.python-version }}
                   auto-activate-base: false
+                  extra-specs: 'python=${{ matrix.python-version }}'
+
             - name: Print environment infos
               shell: bash -l {0}
               run: |
-                  conda info -a
-                  conda list
+                  micromamba info
+                  micromamba list
                   pip list
                   which pip
                   which python
+
             - name: Export Environment
               shell: bash -l {0}
               run: |
                   mkdir -p artifacts
                   filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  conda env export --no-builds | grep -v "prefix" > artifacts/$filename
-            - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
-              with:
-                  name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
-                  path: artifacts/*
-            - name: Install package and test
-              shell: bash -l {0}
-              run: |
-                  pip install -e .
-                  pytest
-            - name: Upload Coverage
-              shell: bash -l {0}
-              run: |
-                  pip install coveralls && coveralls --service=github
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-                  COVERALLS_PARALLEL: true
+                  micromamba env export --no-builds > artifacts/$filename
 
-    windows-tests:
-        name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                python-version: ['3.10']
-                os: ['windows-latest']
-                ymlfile: ['environment.yml']
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  submodules: true
-            - uses: conda-incubator/setup-miniconda@v3
-              with:
-                  miniconda-version: 'latest'
-                  auto-update-conda: true
-                  python-version: ${{ matrix.python-version }}
-                  environment-file: ${{ matrix.ymlfile }}
-                  activate-environment: qa4sm_reader # todo: must match with name in environment.yml
-                  auto-activate-base: false
-            - name: Print environment infos
-              shell: cmd
-              run: |
-                  conda info -a
-                  conda list
-                  pip list
-                  where pip
-                  where python
-            - name: Export Environment
-              shell: cmd
-              run: |
-                  mkdir artifacts
-                  set filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  conda env export --no-builds | findstr /v "prefix" > artifacts/%filename%
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4
               with:
                   name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
                   path: artifacts/*
+
             - name: Install package and test
-              shell: cmd
+              shell: bash -l {0}
               run: |
-                  conda activate qa4sm_reader
                   pip install -e .
                   pytest
+
             - name: Upload Coverage
-              shell: cmd
+              shell: bash -l {0}
               run: |
                   pip install coveralls && coveralls --service=github
               env:
@@ -124,7 +80,7 @@ jobs:
 
     coveralls:
         name: Submit Coveralls 👚
-        needs: [linux-tests, windows-tests]
+        needs: build
         runs-on: ubuntu-latest
         container: python:3-slim
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # This workflow will install Python dependencies and run tests on
-# windows and linux systems with a variety of Python versions
+# Windows and Linux systems with a variety of Python versions
 
 name: tests
 
@@ -11,7 +11,7 @@ on:
         - cron: '0 0 * * *' # daily
 
 jobs:
-    linux-tests:
+    build:
         name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
         runs-on: ${{ matrix.os }}
         strategy:
@@ -19,6 +19,11 @@ jobs:
                 python-version: ['3.8', '3.9', '3.10']
                 os: ['ubuntu-latest']
                 ymlfile: ['environment.yml']
+                include:
+                    - os: 'windows-latest'
+                      python-version: '3.10'
+                      ymlfile: 'environment.yml'
+
         steps:
             - uses: actions/checkout@v2
               with:
@@ -27,23 +32,39 @@ jobs:
             - uses: mamba-org/setup-micromamba@v1
               with:
                   micromamba-version: 'latest'
-                  environment-file: ${{ matrix.ymlfile }} # Ensure the env file is correctly defined
                   micromamba-root-path: ~/micromamba # Optional, where to install micromamba
 
-            - name: Initialize micromamba environment
+            - name: Initialize micromamba environment (Linux)
+              if: runner.os == 'Linux'
               shell: bash -l {0}
               run: |
                   micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
+                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                   echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
 
-            - name: Create and activate environment
+            - name: Initialize micromamba environment (Windows)
+              if: runner.os == 'Windows'
+              shell: cmd
+              run: |
+                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
+                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
+
+            - name: Activate environment (Linux)
+              if: runner.os == 'Linux'
               shell: bash -l {0}
               run: |
                   source ~/micromamba/etc/profile.d/micromamba.sh
-                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                   micromamba activate qa4sm_reader
 
-            - name: Print environment infos
+            - name: Activate environment (Windows)
+              if: runner.os == 'Windows'
+              shell: cmd
+              run: |
+                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
+                  micromamba activate qa4sm_reader
+
+            - name: Print environment infos (Linux)
+              if: runner.os == 'Linux'
               shell: bash -l {0}
               run: |
                   micromamba info
@@ -52,66 +73,8 @@ jobs:
                   which pip
                   which python
 
-            - name: Export Environment
-              shell: bash -l {0}
-              run: |
-                  mkdir -p artifacts
-                  filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export --name qa4sm_reader > artifacts/$filename
-
-            - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
-              with:
-                  name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
-                  path: artifacts/*
-
-            - name: Install package and test
-              shell: bash -l {0}
-              run: |
-                  pip install -e .
-                  pytest
-
-            - name: Upload Coverage
-              shell: bash -l {0}
-              run: |
-                  pip install coveralls && coveralls --service=github
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-                  COVERALLS_PARALLEL: true
-
-    windows-tests:
-        name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                python-version: ['3.10']
-                os: ['windows-latest']
-                ymlfile: ['environment.yml']
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  submodules: true
-
-            - uses: mamba-org/setup-micromamba@v1
-              with:
-                  micromamba-version: 'latest'
-                  environment-file: ${{ matrix.ymlfile }} # Ensure the env file is correctly defined
-                  micromamba-root-path: ~/micromamba # Optional, where to install micromamba
-
-            - name: Initialize micromamba environment
-              shell: cmd
-              run: |
-                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
-
-            - name: Create and activate environment
-              shell: cmd
-              run: |
-                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
-                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
-                  micromamba activate qa4sm_reader
-
-            - name: Print environment infos
+            - name: Print environment infos (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   micromamba info
@@ -120,7 +83,16 @@ jobs:
                   where pip
                   where python
 
-            - name: Export Environment
+            - name: Export Environment (Linux)
+              if: runner.os == 'Linux'
+              shell: bash -l {0}
+              run: |
+                  mkdir -p artifacts
+                  filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
+                  micromamba env export --name qa4sm_reader > artifacts/$filename
+
+            - name: Export Environment (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   mkdir artifacts
@@ -131,15 +103,34 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
-                  path: artifacts\*
+                  path: artifacts/*
 
-            - name: Install package and test
+            - name: Install package and test (Linux)
+              if: runner.os == 'Linux'
+              shell: bash -l {0}
+              run: |
+                  pip install -e .
+                  pytest
+
+            - name: Install package and test (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   pip install -e .
                   pytest
 
-            - name: Upload Coverage
+            - name: Upload Coverage (Linux)
+              if: runner.os == 'Linux'
+              shell: bash -l {0}
+              run: |
+                  pip install coveralls && coveralls --service=github
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                  COVERALLS_PARALLEL: true
+
+            - name: Upload Coverage (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   pip install coveralls && coveralls --service=github
@@ -150,7 +141,7 @@ jobs:
 
     coveralls:
         name: Submit Coveralls 👚
-        needs: [linux-tests, windows-tests]
+        needs: build
         runs-on: ubuntu-latest
         container: python:3-slim
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
               if: runner.os == 'Windows'
               shell: cmd
               run: |
+                  set "PATH=%PATH%;%USERPROFILE%\micromamba\bin"
                   micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
                   micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,8 @@ jobs:
         strategy:
             matrix:
                 python-version: ['3.8', '3.9', '3.10']
-                os: ['ubuntu-latest']
+                os: ['ubuntu-latest', 'windows-latest']
                 ymlfile: ['environment.yml']
-                include:
-                    - os: 'windows-latest'
-                      python-version: '3.10'
-                      ymlfile: 'environment.yml'
         steps:
             - uses: actions/checkout@v2
               with:
@@ -37,71 +33,50 @@ jobs:
                   environment-file: ${{ matrix.ymlfile }}
                   micromamba-root-path: ~/micromamba
 
-            - name: Initialize micromamba environment (Linux)
-              if: runner.os == 'Linux'
+            - name: Initialize micromamba environment
               shell: bash -l {0}
               run: |
-                  micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
-                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
-                  echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
+                  if [ "${{ runner.os }}" == "Linux" ]; then
+                    micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
+                    micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
+                    echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
+                  else
+                    set "PATH=%PATH%;%USERPROFILE%\micromamba\bin"
+                    micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
+                    micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
+                  fi
 
-            - name: Initialize micromamba environment (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
-              run: |
-                  set "PATH=%PATH%;%USERPROFILE%\micromamba\bin"
-                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
-                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
-
-            - name: Activate environment (Linux)
-              if: runner.os == 'Linux'
+            - name: Activate environment
               shell: bash -l {0}
               run: |
-                  source ~/micromamba/etc/profile.d/micromamba.sh
-                  micromamba activate qa4sm_reader
+                  if [ "${{ runner.os }}" == "Linux" ]; then
+                    source ~/micromamba/etc/profile.d/micromamba.sh
+                    micromamba activate qa4sm_reader
+                  else
+                    call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
+                    micromamba activate qa4sm_reader
+                  fi
 
-            - name: Activate environment (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
-              run: |
-                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
-                  micromamba activate qa4sm_reader
-
-            - name: Print environment infos (Linux)
-              if: runner.os == 'Linux'
+            - name: Print environment infos
               shell: bash -l {0}
               run: |
                   micromamba info
                   micromamba list
                   pip list
-                  which pip
-                  which python
+                  if [ "${{ runner.os }}" == "Linux" ]; then
+                    which pip
+                    which python
+                  else
+                    where pip
+                    where python
+                  fi
 
-            - name: Print environment infos (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
-              run: |
-                  micromamba info
-                  micromamba list
-                  pip list
-                  where pip
-                  where python
-
-            - name: Export Environment (Linux)
-              if: runner.os == 'Linux'
+            - name: Export Environment
               shell: bash -l {0}
               run: |
                   mkdir -p artifacts
                   filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
                   micromamba env export --name qa4sm_reader > artifacts/$filename
-
-            - name: Export Environment (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
-              run: |
-                  mkdir artifacts
-                  set filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export --name qa4sm_reader > artifacts\%filename%
 
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4
@@ -109,33 +84,14 @@ jobs:
                   name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
                   path: artifacts/*
 
-            - name: Install package and test (Linux)
-              if: runner.os == 'Linux'
+            - name: Install package and test
               shell: bash -l {0}
               run: |
                   pip install -e .
                   pytest
 
-            - name: Install package and test (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
-              run: |
-                  pip install -e .
-                  pytest
-
-            - name: Upload Coverage (Linux)
-              if: runner.os == 'Linux'
+            - name: Upload Coverage
               shell: bash -l {0}
-              run: |
-                  pip install coveralls && coveralls --service=github
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-                  COVERALLS_PARALLEL: true
-
-            - name: Upload Coverage (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
               run: |
                   pip install coveralls && coveralls --service=github
               env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 # This workflow will install Python dependencies and run tests on
-# windows and linux systems with a variety of Python versions
+# Windows and Linux systems with a variety of Python versions
+
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: tests
 
@@ -11,7 +14,7 @@ on:
         - cron: '0 0 * * *' # daily
 
 jobs:
-    linux-tests:
+    build:
         name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
         runs-on: ${{ matrix.os }}
         strategy:
@@ -19,6 +22,10 @@ jobs:
                 python-version: ['3.8', '3.9', '3.10']
                 os: ['ubuntu-latest']
                 ymlfile: ['environment.yml']
+                include:
+                    - os: 'windows-latest'
+                      python-version: '3.10'
+                      ymlfile: 'environment.yml'
         steps:
             - uses: actions/checkout@v2
               with:
@@ -27,23 +34,40 @@ jobs:
             - uses: mamba-org/setup-micromamba@v1
               with:
                   micromamba-version: 'latest'
-                  environment-file: ${{ matrix.ymlfile }} # Ensure the env file is correctly defined
-                  micromamba-root-path: ~/micromamba # Optional, where to install micromamba
+                  environment-file: ${{ matrix.ymlfile }}
+                  micromamba-root-path: ~/micromamba
 
-            - name: Initialize micromamba environment
+            - name: Initialize micromamba environment (Linux)
+              if: runner.os == 'Linux'
               shell: bash -l {0}
               run: |
                   micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
+                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                   echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
 
-            - name: Create and activate environment
+            - name: Initialize micromamba environment (Windows)
+              if: runner.os == 'Windows'
+              shell: cmd
+              run: |
+                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
+                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
+
+            - name: Activate environment (Linux)
+              if: runner.os == 'Linux'
               shell: bash -l {0}
               run: |
                   source ~/micromamba/etc/profile.d/micromamba.sh
-                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                   micromamba activate qa4sm_reader
 
-            - name: Print environment infos
+            - name: Activate environment (Windows)
+              if: runner.os == 'Windows'
+              shell: cmd
+              run: |
+                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
+                  micromamba activate qa4sm_reader
+
+            - name: Print environment infos (Linux)
+              if: runner.os == 'Linux'
               shell: bash -l {0}
               run: |
                   micromamba info
@@ -52,73 +76,8 @@ jobs:
                   which pip
                   which python
 
-            - name: Export Environment
-              shell: bash -l {0}
-              run: |
-                  mkdir -p artifacts
-                  filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export --name qa4sm_reader > artifacts/$filename
-
-            - name: Upload Artifacts
-              uses: actions/upload-artifact@v4
-              with:
-                  name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
-                  path: artifacts/*
-
-            - name: Install package and test
-              shell: bash -l {0}
-              run: |
-                  pip install -e .
-                  pytest
-
-            - name: Upload Coverage
-              shell: bash -l {0}
-              run: |
-                  pip install coveralls && coveralls --service=github
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-                  COVERALLS_PARALLEL: true
-
-    windows-tests:
-        name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                python-version: ['3.10']
-                os: ['windows-latest']
-                ymlfile: ['environment.yml']
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  submodules: true
-
-            - name: Install Micromamba
-              shell: cmd
-              run: |
-                  curl -Ls https://micromamba.snakepit.net/api/micromamba/win-64/latest | tar -xvj -C C:\micromamba\bin
-                  set PATH=C:\micromamba\bin;%PATH%
-                  micromamba --version
-
-            - uses: mamba-org/setup-micromamba@v1
-              with:
-                  micromamba-version: 'latest'
-                  environment-file: ${{ matrix.ymlfile }}
-                  micromamba-root-path: C:\micromamba
-
-            - name: Initialize micromamba environment
-              shell: cmd
-              run: |
-                  micromamba shell init -s cmd -p C:\micromamba\envs\qa4sm_reader
-
-            - name: Create and activate environment
-              shell: cmd
-              run: |
-                  call C:\micromamba\etc\profile.d\micromamba.cmd
-                  micromamba create -y --name qa4sm_reader --file C:\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
-                  micromamba activate qa4sm_reader
-
-            - name: Print environment infos
+            - name: Print environment infos (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   micromamba info
@@ -127,7 +86,16 @@ jobs:
                   where pip
                   where python
 
-            - name: Export Environment
+            - name: Export Environment (Linux)
+              if: runner.os == 'Linux'
+              shell: bash -l {0}
+              run: |
+                  mkdir -p artifacts
+                  filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
+                  micromamba env export --name qa4sm_reader > artifacts/$filename
+
+            - name: Export Environment (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   mkdir artifacts
@@ -138,15 +106,34 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
-                  path: artifacts\*
+                  path: artifacts/*
 
-            - name: Install package and test
+            - name: Install package and test (Linux)
+              if: runner.os == 'Linux'
+              shell: bash -l {0}
+              run: |
+                  pip install -e .
+                  pytest
+
+            - name: Install package and test (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   pip install -e .
                   pytest
 
-            - name: Upload Coverage
+            - name: Upload Coverage (Linux)
+              if: runner.os == 'Linux'
+              shell: bash -l {0}
+              run: |
+                  pip install coveralls && coveralls --service=github
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                  COVERALLS_PARALLEL: true
+
+            - name: Upload Coverage (Windows)
+              if: runner.os == 'Windows'
               shell: cmd
               run: |
                   pip install coveralls && coveralls --service=github
@@ -157,7 +144,7 @@ jobs:
 
     coveralls:
         name: Submit Coveralls 👚
-        needs: [linux-tests, windows-tests]
+        needs: build
         runs-on: ubuntu-latest
         container: python:3-slim
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
                     micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                     echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
                   else
-                    set "PATH=%PATH%;%USERPROFILE%\micromamba\bin"
+                    echo "set PATH=%PATH%;%USERPROFILE%\micromamba\bin" >> $GITHUB_ENV
                     micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
                     micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
                   fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # This workflow will install Python dependencies and run tests on
-# Windows and Linux systems with a variety of Python versions
+# windows and linux systems with a variety of Python versions
 
 name: tests
 
@@ -11,7 +11,7 @@ on:
         - cron: '0 0 * * *' # daily
 
 jobs:
-    build:
+    linux-tests:
         name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
         runs-on: ${{ matrix.os }}
         strategy:
@@ -19,11 +19,6 @@ jobs:
                 python-version: ['3.8', '3.9', '3.10']
                 os: ['ubuntu-latest']
                 ymlfile: ['environment.yml']
-                include:
-                    - os: 'windows-latest'
-                      python-version: '3.10'
-                      ymlfile: 'environment.yml'
-
         steps:
             - uses: actions/checkout@v2
               with:
@@ -32,39 +27,23 @@ jobs:
             - uses: mamba-org/setup-micromamba@v1
               with:
                   micromamba-version: 'latest'
+                  environment-file: ${{ matrix.ymlfile }} # Ensure the env file is correctly defined
                   micromamba-root-path: ~/micromamba # Optional, where to install micromamba
 
-            - name: Initialize micromamba environment (Linux)
-              if: runner.os == 'Linux'
+            - name: Initialize micromamba environment
               shell: bash -l {0}
               run: |
                   micromamba shell init -s bash -p ~/micromamba/envs/qa4sm_reader
-                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                   echo "source ~/micromamba/etc/profile.d/micromamba.sh" >> ~/.bashrc
 
-            - name: Initialize micromamba environment (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
-              run: |
-                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
-                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
-
-            - name: Activate environment (Linux)
-              if: runner.os == 'Linux'
+            - name: Create and activate environment
               shell: bash -l {0}
               run: |
                   source ~/micromamba/etc/profile.d/micromamba.sh
+                  micromamba create -y --name qa4sm_reader --file ${{ matrix.ymlfile }}
                   micromamba activate qa4sm_reader
 
-            - name: Activate environment (Windows)
-              if: runner.os == 'Windows'
-              shell: cmd
-              run: |
-                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
-                  micromamba activate qa4sm_reader
-
-            - name: Print environment infos (Linux)
-              if: runner.os == 'Linux'
+            - name: Print environment infos
               shell: bash -l {0}
               run: |
                   micromamba info
@@ -73,8 +52,73 @@ jobs:
                   which pip
                   which python
 
-            - name: Print environment infos (Windows)
-              if: runner.os == 'Windows'
+            - name: Export Environment
+              shell: bash -l {0}
+              run: |
+                  mkdir -p artifacts
+                  filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
+                  micromamba env export --name qa4sm_reader > artifacts/$filename
+
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
+                  path: artifacts/*
+
+            - name: Install package and test
+              shell: bash -l {0}
+              run: |
+                  pip install -e .
+                  pytest
+
+            - name: Upload Coverage
+              shell: bash -l {0}
+              run: |
+                  pip install coveralls && coveralls --service=github
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                  COVERALLS_PARALLEL: true
+
+    windows-tests:
+        name: Build py${{ matrix.python-version }} @ ${{ matrix.os }} 🐍
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                python-version: ['3.10']
+                os: ['windows-latest']
+                ymlfile: ['environment.yml']
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - name: Install Micromamba
+              shell: cmd
+              run: |
+                  curl -Ls https://micromamba.snakepit.net/api/micromamba/win-64/latest | tar -xvj -C %USERPROFILE%\micromamba\bin
+                  set PATH=%USERPROFILE%\micromamba\bin;%PATH%
+                  micromamba --version
+
+            - uses: mamba-org/setup-micromamba@v1
+              with:
+                  micromamba-version: 'latest'
+                  environment-file: ${{ matrix.ymlfile }}
+                  micromamba-root-path: %USERPROFILE%\micromamba
+
+            - name: Initialize micromamba environment
+              shell: cmd
+              run: |
+                  micromamba shell init -s cmd -p %USERPROFILE%\micromamba\envs\qa4sm_reader
+
+            - name: Create and activate environment
+              shell: cmd
+              run: |
+                  call %USERPROFILE%\micromamba\etc\profile.d\micromamba.cmd
+                  micromamba create -y --name qa4sm_reader --file %USERPROFILE%\micromamba\envs\qa4sm_reader\${{ matrix.ymlfile }}
+                  micromamba activate qa4sm_reader
+
+            - name: Print environment infos
               shell: cmd
               run: |
                   micromamba info
@@ -83,16 +127,7 @@ jobs:
                   where pip
                   where python
 
-            - name: Export Environment (Linux)
-              if: runner.os == 'Linux'
-              shell: bash -l {0}
-              run: |
-                  mkdir -p artifacts
-                  filename=env_py${{ matrix.python-version }}_${{ matrix.os }}.yml
-                  micromamba env export --name qa4sm_reader > artifacts/$filename
-
-            - name: Export Environment (Windows)
-              if: runner.os == 'Windows'
+            - name: Export Environment
               shell: cmd
               run: |
                   mkdir artifacts
@@ -103,34 +138,15 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: Artifacts-py${{ matrix.python-version }}-${{ matrix.os }}
-                  path: artifacts/*
+                  path: artifacts\*
 
-            - name: Install package and test (Linux)
-              if: runner.os == 'Linux'
-              shell: bash -l {0}
-              run: |
-                  pip install -e .
-                  pytest
-
-            - name: Install package and test (Windows)
-              if: runner.os == 'Windows'
+            - name: Install package and test
               shell: cmd
               run: |
                   pip install -e .
                   pytest
 
-            - name: Upload Coverage (Linux)
-              if: runner.os == 'Linux'
-              shell: bash -l {0}
-              run: |
-                  pip install coveralls && coveralls --service=github
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-                  COVERALLS_PARALLEL: true
-
-            - name: Upload Coverage (Windows)
-              if: runner.os == 'Windows'
+            - name: Upload Coverage
               shell: cmd
               run: |
                   pip install coveralls && coveralls --service=github
@@ -141,7 +157,7 @@ jobs:
 
     coveralls:
         name: Submit Coveralls 👚
-        needs: build
+        needs: [linux-tests, windows-tests]
         runs-on: ubuntu-latest
         container: python:3-slim
         steps:

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ tests/test_data/out/*
 */_local_scripts/*
 .coverage*
 .artifacts/*
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,4 @@ except VersionConflict:
     sys.exit(1)
 
 if __name__ == "__main__":
-    setup(use_pyscaffold=True,
-          install_requires=[
-              'pytest',
-              'pytest-cov',
-              'parse',
-          ])
+    setup(use_pyscaffold=True)

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,9 @@ except VersionConflict:
     sys.exit(1)
 
 if __name__ == "__main__":
-    setup(use_pyscaffold=True)
+    setup(
+        use_pyscaffold=True,
+        install_requires=[
+            'pytest',
+            # other dependencies
+        ])

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ if __name__ == "__main__":
         use_pyscaffold=True,
         install_requires=[
             'pytest',
+            'pytest-cov',
             # other dependencies
         ])

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,9 @@ except VersionConflict:
     sys.exit(1)
 
 if __name__ == "__main__":
-    setup(
-        use_pyscaffold=True,
-        install_requires=[
-            'pytest',
-            'pytest-cov',
-            # other dependencies
-        ])
+    setup(use_pyscaffold=True,
+          install_requires=[
+              'pytest',
+              'pytest-cov',
+              'parse',
+          ])


### PR DESCRIPTION
- Separated windows and linux workflows
- Disabled mamba in windows workflow, as this causes `conda-incubator/setup-miniconda@v3` to fail currently (https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-6.yml)