### PR TITLE
Add metadata plotting by network (Adjust plot parameters depending on number of networks)

### DIFF
--- a/src/qa4sm_reader/globals.py
+++ b/src/qa4sm_reader/globals.py
@@ -70,12 +70,12 @@ watermark_logo_pth = os.path.join(
 
 # === metadata network defaults ===
 meta_network_base_font_size = 0.9
-meta_network_font_scale_rate = 0.03
+meta_network_font_scale_rate = 0.04
 meta_network_boxplot_width = 12.6
 meta_network_width_scale_rate = 0.34
 meta_network_boxplot_height = 5
 meta_network_boxplot_height_scale_factor = 0.5
-meta_network_increase_padding_rate = 1.7
+meta_network_increase_padding_rate = 1.4
 
 # === filename template ===
 ds_fn_templ = "{i}-{ds}.{var}"
@@ -659,7 +659,7 @@ def get_resolution_info(dataset, raise_error=False):
 # information needed for plotting the metadata-boxplots
 
 # Min number of samples per bin to create a boxplot:
-meta_boxplot_min_samples = 5
+meta_boxplot_min_samples = 1
 
 lc_classes = {
     "unknown": "Not provided",

--- a/src/qa4sm_reader/globals.py
+++ b/src/qa4sm_reader/globals.py
@@ -68,6 +68,14 @@ watermark_logo_pth = os.path.join(
         os.path.abspath(__file__)), 'static', 'images', 'logo',
     'QA4SM_logo_long.png')
 
+# === metadata network defaults ===
+meta_network_base_font_size = 0.9
+meta_network_font_scale_rate = 0.03
+meta_network_boxplot_width = 12.6
+meta_network_width_scale_rate = 0.34
+meta_network_boxplot_height = 5
+meta_network_boxplot_height_scale_factor = 0.5
+meta_network_increase_padding_rate = 1.7
 
 # === filename template ===
 ds_fn_templ = "{i}-{ds}.{var}"
@@ -79,6 +87,7 @@ out_metadata_plots = {
     "climate": ["climate_KG"],
     "soil": ["instrument_depth", "soil_type"],
     "frm_class": ['frm_class'],
+    "network" : ['network'],
 }
 
 # === calculation errors (pytesmo) === #TODO: import from pytesmo

--- a/src/qa4sm_reader/plotter.py
+++ b/src/qa4sm_reader/plotter.py
@@ -19,7 +19,7 @@ from matplotlib.patches import Rectangle
 from qa4sm_reader.img import QA4SMImg
 import qa4sm_reader.globals as globals
 from qa4sm_reader import plotting_methods as plm
-from qa4sm_reader.plotting_methods import ClusteredBoxPlot, patch_styling
+from qa4sm_reader.plotting_methods import ClusteredBoxPlot, patch_styling, scale_figure_for_network_metadata_plot
 from qa4sm_reader.exceptions import PlotterError
 import qa4sm_reader.handlers as hdl
 from qa4sm_reader.utils import note, filter_out_self_combination_tcmetric_vars
@@ -119,7 +119,7 @@ class QA4SMPlotter:
         ds_parts = []
         id, meta = mds_meta
         if tc:
-            id, meta = other_meta   # show name of the OTHER dataset
+            id, meta = other_meta  # show name of the OTHER dataset
         if short_caption:
             ds_parts.append(
                 f"{id}-{meta['pretty_name']} ({meta['pretty_version']})")
@@ -414,13 +414,13 @@ class QA4SMPlotter:
 
         # fig.tight_layout()
 
-        plm.add_logo_to_figure(fig = fig,
-                               logo_path = globals.watermark_logo_pth,
-                               position = globals.watermark_logo_position,
-                               offset = globals.watermark_logo_offset_box_plots,
-                               scale = globals.watermark_logo_scale,
-                               )
-
+        plm.add_logo_to_figure(
+            fig=fig,
+            logo_path=globals.watermark_logo_pth,
+            position=globals.watermark_logo_position,
+            offset=globals.watermark_logo_offset_box_plots,
+            scale=globals.watermark_logo_scale,
+        )
 
         return fig, ax
 
@@ -465,14 +465,17 @@ class QA4SMPlotter:
         ax.set_title(title, pad=globals.title_pad)
 
         # add watermark
-        plm.add_logo_to_figure(fig = fig,
-                               logo_path = globals.watermark_logo_pth,
-                               position = globals.watermark_logo_position,
-                               offset = globals.watermark_logo_offset_bar_plots,
-                               scale = globals.watermark_logo_scale,
-                               )
+        plm.add_logo_to_figure(
+            fig=fig,
+            logo_path=globals.watermark_logo_pth,
+            position=globals.watermark_logo_position,
+            offset=globals.watermark_logo_offset_bar_plots,
+            scale=globals.watermark_logo_scale,
+        )
 
-    def _save_plot(self, out_name: str, out_types: Optional[Union[List[str], str]] = 'png') -> list:
+    def _save_plot(self,
+                   out_name: str,
+                   out_types: Optional[Union[List[str], str]] = 'png') -> list:
         """
         Save plot with name to self.out_dir
 
@@ -764,7 +767,8 @@ class QA4SMPlotter:
             metric=metric,
             ref_short=ref_meta[1]['short_name'],
             ref_grid_stepsize=ref_grid_stepsize,
-            plot_extent=None,  # if None, extent is automatically adjusted (as opposed to img.extent)
+            plot_extent=
+            None,  # if None, extent is automatically adjusted (as opposed to img.extent)
             scl_short=scl_short,
             **style_kwargs)
 
@@ -802,12 +806,13 @@ class QA4SMPlotter:
         # use title for plot, make watermark
         ax.set_title(title, pad=globals.title_pad)
 
-        plm.add_logo_to_figure(fig = fig,
-                               logo_path = globals.watermark_logo_pth,
-                               position = globals.watermark_logo_position,
-                               offset = globals.watermark_logo_offset_map_plots,
-                               scale = globals.watermark_logo_scale,
-                               )
+        plm.add_logo_to_figure(
+            fig=fig,
+            logo_path=globals.watermark_logo_pth,
+            position=globals.watermark_logo_position,
+            offset=globals.watermark_logo_offset_map_plots,
+            scale=globals.watermark_logo_scale,
+        )
 
         # save file or just return the image
         if save_files:
@@ -845,7 +850,8 @@ class QA4SMPlotter:
         fnames = []
         for Var in self.img._iter_vars(type="metric",
                                        filter_parms={"metric": metric}):
-            if len(self.img.triple) and Var.g == 'pairwise' and metric == 'status':
+            if len(self.img.triple
+                   ) and Var.g == 'pairwise' and metric == 'status':
                 continue
             if not (np.isnan(Var.values.to_numpy()).all() or Var.is_CI):
                 fns = self.mapplot_var(Var,
@@ -884,7 +890,7 @@ class QA4SMPlotter:
         """
         fnames_bplot = None
         Metric = self.img.metrics[metric]
-        
+
         fnames_mapplot = None
         if Metric.name == 'status':
             fnames_bplot = self.barplot(metric='status',
@@ -909,7 +915,7 @@ class QA4SMPlotter:
                                                  period=period,
                                                  out_types=out_types,
                                                  save_files=save_all,
-                                                 **plotting_kwargs)            
+                                                 **plotting_kwargs)
 
         return fnames_bplot, fnames_mapplot
 
@@ -982,7 +988,6 @@ class QA4SMPlotter:
             else:
                 colmean = values.pop(col).mean(axis=1, skipna=True)
                 values[col] = colmean
-
 
         out = plm.boxplot_metadata(df=values,
                                    metadata_values=meta_values,
@@ -1140,12 +1145,18 @@ class QA4SMPlotter:
 
         fig.subplots_adjust(bottom=0.2)
 
-        plm.add_logo_to_figure(fig = fig,
-                               logo_path = globals.watermark_logo_pth,
-                               position = globals.watermark_logo_position,
-                               offset = globals.watermark_logo_offset_metadata_plots,
-                               scale = globals.watermark_logo_scale,
-                               )
+        watermark_scale = globals.watermark_logo_scale
+        if metadata == 'network':
+            fig, ax, watermark_scale = scale_figure_for_network_metadata_plot(
+                fig=fig, ax=ax, watermark_scale=watermark_scale)
+
+        plm.add_logo_to_figure(
+            fig=fig,
+            logo_path=globals.watermark_logo_pth,
+            position=globals.watermark_logo_position,
+            offset=globals.watermark_logo_offset_metadata_plots,
+            scale=watermark_scale,
+        )
 
         if save_file:
             out_name = self._filenames_lut("metadata").format(
@@ -1231,6 +1242,7 @@ class QA4SMPlotter:
         table.to_csv(path_or_buf=filepath)
 
         return filepath
+
 
 #$$
 class QA4SMCompPlotter:
@@ -1373,10 +1385,10 @@ class QA4SMCompPlotter:
             pattern = globals.METRIC_TEMPLATE.format(
                 ds1=
                 r'(?P<ds1>\d+-\w+)',  # matches one or more digits (\d+), followed by a hyphen (-), \
-                                     # followed by one or more word characters (\w+)
+                # followed by one or more word characters (\w+)
                 ds2=
                 r'(?P<ds2>\d+-\w+)',  # matches one or more digits (\d+), followed by a hyphen (-), \
-                                     # followed by one or more word characters (\w+)
+                # followed by one or more word characters (\w+)
             )
 
             match = re.search(pattern, metric_string)
@@ -1432,8 +1444,8 @@ class QA4SMCompPlotter:
         """
 
         temp_sub_wins_names = [
-            tsw
-            for tsw in self.ds.coords[globals.TEMPORAL_SUB_WINDOW_NC_COORD_NAME].values
+            tsw for tsw in self.ds.coords[
+                globals.TEMPORAL_SUB_WINDOW_NC_COORD_NAME].values
             if tsw != globals.DEFAULT_TSW
         ]
 
@@ -1501,8 +1513,7 @@ class QA4SMCompPlotter:
     @staticmethod
     @note(
         "This method is redundant, as it yields the same result as `QA4SMCompPlotter.tsws_used()`. \
-        It is kept as a static method for debugging purposes."
-    )
+        It is kept as a static method for debugging purposes.")
     def get_tsws_from_df(df: pd.DataFrame) -> List[str]:
         """
         Get all temporal sub-windows used in the validation from a DataFrame as returned by \
@@ -1688,10 +1699,12 @@ class QA4SMCompPlotter:
 
             yield Var
 
-    def plot_cbp(self,
-                 chosen_metric: str,
-                 stability: bool,
-                 out_name: Optional[Union[List, List[str]]] = None) -> matplotlib.figure.Figure:
+    def plot_cbp(
+        self,
+        chosen_metric: str,
+        stability: bool,
+        out_name: Optional[Union[List, List[str]]] = None
+    ) -> matplotlib.figure.Figure:
         """
         Plot a Clustered Boxplot for a chosen metric
 
@@ -1709,6 +1722,7 @@ class QA4SMCompPlotter:
 
         """
         anchor_list = None
+
         def get_metric_vars(
                 generic_metric: str) -> Dict[str, hdl.MetricVariable]:
             _dict = {}
@@ -1738,6 +1752,7 @@ class QA4SMCompPlotter:
                     unit=Var.metric_ds[1]["mu"])
                 for Var in get_metric_vars(generic_metric).values()
             }
+
         def sanitize_dataframe(df: pd.DataFrame,
                                column_threshold: float = 0.1,
                                row_threshold_fraction: float = 0.8,
@@ -1798,19 +1813,20 @@ class QA4SMCompPlotter:
 
         legend_entries = get_legend_entries(cbp_obj=self.cbp,
                                             generic_metric=chosen_metric)
-        
+
         anchor_list = None
         if stability:
-             # get the first dataset to deduce the number of anchors - important for the boxplot setup
-             unique_groups = metric_df.columns.get_level_values(0).unique()           
-             first_df = metric_df.loc[:, metric_df.columns.get_level_values(0) == unique_groups[0]]
-             first_df = sanitize_dataframe(first_df, keep_empty_cols=False)
-             anchor_number = len(first_df.columns)
-             anchor_list = np.arange(anchor_number).astype(float)
+            # get the first dataset to deduce the number of anchors - important for the boxplot setup
+            unique_groups = metric_df.columns.get_level_values(0).unique()
+            first_df = metric_df.loc[:,
+                                     metric_df.columns.get_level_values(0) ==
+                                     unique_groups[0]]
+            first_df = sanitize_dataframe(first_df, keep_empty_cols=False)
+            anchor_number = len(first_df.columns)
+            anchor_list = np.arange(anchor_number).astype(float)
 
         if anchor_list is None:
             anchor_list = self.cbp.anchor_list
-
 
         centers_and_widths = self.cbp.centers_and_widths(
             anchor_list=anchor_list,
@@ -1831,17 +1847,19 @@ class QA4SMCompPlotter:
 
         legend_entries = get_legend_entries(cbp_obj=self.cbp,
                                             generic_metric=chosen_metric)
-        
+
         cbp_fig = self.cbp.figure_template(incl_median_iqr_n_axs=False,
                                            fig_kwargs=fig_kwargs)
-        
+
         legend_handles = []
         for dc_num, (dc_val_name, Var) in enumerate(Vars.items()):
             _df = Var.values  # get the dataframe for the specific metric, potentially with NaNs
             if not stability:
-                _df = sanitize_dataframe(_df, keep_empty_cols=True)  # sanitize the dataframe
+                _df = sanitize_dataframe(
+                    _df, keep_empty_cols=True)  # sanitize the dataframe
             else:
-                _df = sanitize_dataframe(_df, keep_empty_cols=False)  # remove redundant columns
+                _df = sanitize_dataframe(
+                    _df, keep_empty_cols=False)  # remove redundant columns
             bp = cbp_fig.ax_box.boxplot(
                 [_df[col] for col in _df.columns],
                 positions=centers_and_widths[dc_num].centers,
@@ -1884,11 +1902,10 @@ class QA4SMCompPlotter:
             ['legend_fontsize'],
             ncols=_ncols)
 
-        xtick_pos = self.cbp.centers_and_widths(
-            anchor_list=anchor_list,
-            no_of_ds=1,
-            space_per_box_cluster=0.7,
-            rel_indiv_box_width=0.8)
+        xtick_pos = self.cbp.centers_and_widths(anchor_list=anchor_list,
+                                                no_of_ds=1,
+                                                space_per_box_cluster=0.7,
+                                                rel_indiv_box_width=0.8)
         cbp_fig.ax_box.set_xticks([])
         cbp_fig.ax_box.set_xticklabels([])
         cbp_fig.ax_box.set_xticks(xtick_pos[0].centers)
@@ -1899,6 +1916,7 @@ class QA4SMCompPlotter:
                 f"{tsw[1]}\nEmpty" if count == 0 else f"{tsw[1]}"
                 for tsw, count in _count_dict.items()
             ]
+
         xtick_labels = get_xtick_labels(_df)
 
         if len(xtick_labels) > 19 and stability:
@@ -1923,31 +1941,39 @@ class QA4SMCompPlotter:
 
             try:
                 out = list({x for x in df.count() if x > 0})[0]
-            except IndexError: # if all values are NaN
+            except IndexError:  # if all values are NaN
                 out = 0
             return out
 
-        title = title[0:-2] + f'\n for the same {get_valid_gpis(_df)} out of {len(metric_df)} GPIs\n'
+        title = title[
+            0:
+            -2] + f'\n for the same {get_valid_gpis(_df)} out of {len(metric_df)} GPIs\n'
 
         cbp_fig.fig.suptitle(
             title,
             fontsize=globals.CLUSTERED_BOX_PLOT_STYLE['fig_params']
             ['title_fontsize'])
-        
+
         cbp_fig.ax_box.set_ylabel(
             self.create_label(Var),
             fontsize=globals.CLUSTERED_BOX_PLOT_STYLE['fig_params']
             ['y_labelsize'],
         )
 
-        spth = [Path(f"{globals.CLUSTERED_BOX_PLOT_SAVENAME.format(metric = chosen_metric, filetype = 'png')}")]
+        spth = [
+            Path(
+                f"{globals.CLUSTERED_BOX_PLOT_SAVENAME.format(metric = chosen_metric, filetype = 'png')}"
+            )
+        ]
         if out_name:
             spth = out_name
 
-        [cbp_fig.fig.savefig(
-            fname=outname,
-            dpi=fig_kwargs['dpi'],
-            bbox_inches=fig_kwargs['bbox_inches'],
-        ) for outname in spth]
+        [
+            cbp_fig.fig.savefig(
+                fname=outname,
+                dpi=fig_kwargs['dpi'],
+                bbox_inches=fig_kwargs['bbox_inches'],
+            ) for outname in spth
+        ]
 
         return cbp_fig.fig

--- a/src/qa4sm_reader/plotting_methods.py
+++ b/src/qa4sm_reader/plotting_methods.py
@@ -26,7 +26,6 @@ import matplotlib.ticker as mticker
 import matplotlib.gridspec as gridspec
 from matplotlib.patches import Patch, PathPatch
 
-
 from cartopy import config as cconfig
 import cartopy.feature as cfeature
 from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
@@ -38,7 +37,6 @@ from shapely.geometry import Polygon, Point
 import warnings
 import os
 from collections import namedtuple
-
 
 cconfig['data_dir'] = os.path.join(os.path.dirname(__file__), 'cartopy')
 
@@ -323,7 +321,11 @@ def get_plot_extent(df, grid_stepsize=None, grid=False) -> tuple:
     return extent
 
 
-def init_plot(figsize, dpi, add_cbar=None, projection=None, fig_template = None) -> tuple:
+def init_plot(figsize,
+              dpi,
+              add_cbar=None,
+              projection=None,
+              fig_template=None) -> tuple:
     """Initialize mapplot"""
     if not projection:
         projection = globals.crs
@@ -335,7 +337,6 @@ def init_plot(figsize, dpi, add_cbar=None, projection=None, fig_template = None)
         fig = fig_template.fig
         ax_main = fig_template.ax_main
 
-
     if add_cbar:
         gs = gridspec.GridSpec(nrows=2, ncols=1, height_ratios=[19, 1])
         ax_main = fig.add_subplot(gs[0], projection=projection)
@@ -346,6 +347,7 @@ def init_plot(figsize, dpi, add_cbar=None, projection=None, fig_template = None)
         cax = None
 
     return fig, ax_main, cax
+
 
 def get_extend_cbar(metric):
     """
@@ -465,7 +467,6 @@ def style_map(
     return ax
 
 
-
 @note(
     "DeprecationWarning: The function `qa4sm_reader.plotting_methods.make_watermark()` is deprecated and will be removed in the next release. Use `qa4sm_reader.plotting_methods.add_logo_to_figure` instead to add a logo."
 )
@@ -548,13 +549,18 @@ def make_watermark(fig,
     else:
         raise NotImplementedError
 
+
 #$$
-Offset = namedtuple('offset', ['x', 'y']) # helper for offset in add_logo_to_figure
-def add_logo_to_figure(fig: matplotlib.figure.Figure,
-                       logo_path: Optional[str] = globals.watermark_logo_pth,
-                       position: Optional[str] = globals.watermark_logo_position,
-                       offset: Optional[Union[Tuple, Offset]] = (0., -0.15),
-                       scale: Optional[float] = 0.15) -> None:
+Offset = namedtuple('offset',
+                    ['x', 'y'])  # helper for offset in add_logo_to_figure
+
+
+def add_logo_to_figure(
+        fig: matplotlib.figure.Figure,
+        logo_path: Optional[str] = globals.watermark_logo_pth,
+        position: Optional[str] = globals.watermark_logo_position,
+        offset: Optional[Union[Tuple, Offset]] = (0., -0.15),
+        scale: Optional[float] = 0.15) -> None:
     """
     Add a logo to an existing figure. This is done by creating an additional axis in the figure, at the location\
         specified by `position`. The logo is then placed on this axis.
@@ -590,8 +596,12 @@ def add_logo_to_figure(fig: matplotlib.figure.Figure,
         fig.add_subplot(111)
 
     if not os.path.exists(logo_path):
-        warnings.warn(f"No logo found at the specified path: '{logo_path}'. Skipping logo addition.")
-        print(f"No logo found at the specified path: '{logo_path}'. Skipping logo addition.")
+        warnings.warn(
+            f"No logo found at the specified path: '{logo_path}'. Skipping logo addition."
+        )
+        print(
+            f"No logo found at the specified path: '{logo_path}'. Skipping logo addition."
+        )
         return
 
     with cbook.get_sample_data(logo_path) as file:
@@ -610,7 +620,6 @@ def add_logo_to_figure(fig: matplotlib.figure.Figure,
 
     if not isinstance(offset, Offset):
         offset = Offset(*offset)
-
 
     if 'left' in position:
         left = 1 - (logo_width_fig) + offset.x
@@ -1387,7 +1396,7 @@ def _dict2df(to_plot_dict: dict, meta_key: str) -> pd.DataFrame:
 
 def add_cat_info(to_plot: pd.DataFrame, metadata_name: str) -> pd.DataFrame:
     """Add info (N, median value) to metadata category labels"""
-    groups = to_plot.groupby(metadata_name)["values"]#
+    groups = to_plot.groupby(metadata_name)["values"]  #
     counts = {}
     for name, group in groups:
         counts[name] = group[~group.index.duplicated(keep='first')].index.size
@@ -1452,6 +1461,17 @@ def bplot_catplot(to_plot,
     # needed for overlapping station names
     box.tick_params(labelsize=globals.tick_size)
     dims = [globals.boxplot_width * n_meta * 2, globals.boxplot_height]
+    if metadata_name == 'network':
+        dims = [
+            globals.meta_network_boxplot_width +
+            n_meta * globals.meta_network_width_scale_rate,
+            globals.meta_network_boxplot_height +
+            n_meta * globals.meta_network_boxplot_height_scale_factor
+        ]
+        if n_meta > 33:  # change y-labels to one line
+            y_labels = [label.get_text() for label in box.get_yticklabels()]
+            y_labels_fixed = [label.replace("\n", ", ") for label in y_labels]
+            box.set_yticklabels(y_labels_fixed, fontsize=globals.tick_size)
     if orient == "v":
         axis.set(xlabel=None, ylabel=y_axis)
         axis.yaxis.grid(True)  # Hide the horizontal gridlines
@@ -1554,7 +1574,6 @@ def boxplot_metadata(
     elif isinstance(to_plot, pd.DataFrame):
         generate_plot = bplot_catplot
 
-
     out = generate_plot(
         to_plot=to_plot,
         y_axis=ax_label,
@@ -1570,20 +1589,22 @@ def boxplot_metadata(
         return fig, axes
 
 
-def mapplot(df: pd.DataFrame,
-            metric: str,
-            ref_short : str,
-            scl_short: Optional[str] = None,
-            ref_grid_stepsize: Optional[float] = None,
-            plot_extent: Optional[Tuple[float, float, float, float]] = None,
-            colormap=None,
-            projection: Optional[ccrs.Projection] = None,
-            add_cbar: Optional[bool] = True,
-            label: Optional[str] = None,
-            figsize: Optional[Tuple[float, float]] = globals.map_figsize,
-            dpi: Optional[int] = globals.dpi_min,
-            diff_map: Optional[bool] = False,
-            **style_kwargs: Dict) -> Tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]:
+def mapplot(
+    df: pd.DataFrame,
+    metric: str,
+    ref_short: str,
+    scl_short: Optional[str] = None,
+    ref_grid_stepsize: Optional[float] = None,
+    plot_extent: Optional[Tuple[float, float, float, float]] = None,
+    colormap=None,
+    projection: Optional[ccrs.Projection] = None,
+    add_cbar: Optional[bool] = True,
+    label: Optional[str] = None,
+    figsize: Optional[Tuple[float, float]] = globals.map_figsize,
+    dpi: Optional[int] = globals.dpi_min,
+    diff_map: Optional[bool] = False,
+    **style_kwargs: Dict
+) -> Tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]:
     """
         Create an overview map from df using values as color. Plots a scatterplot for ISMN and an image plot for other
         input values.
@@ -1953,6 +1974,67 @@ def average_non_additive(values: Union[pd.Series, np.array],
     # Back transform the result
     return np.tanh(mean)
 
+
+def scale_figure_for_network_metadata_plot(fig: "matplotlib.figure.Figure",
+                                           ax: "matplotlib.axes.Axes",
+                                           watermark_scale: float) -> Tuple:
+    """
+    Scales figure elements based on the number of patches.
+    
+    This function adjusts font sizes of various figure elements including title,
+    tick labels, axis labels, and legend text. It also adjusts the layout and
+    subplot parameters based on the number of patches in the axes.
+    
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure object to scale.
+    ax : matplotlib.axes.Axes
+        The axes object containing the patches to consider for scaling.
+    watermark_scale : float
+        The initial watermark scale factor that will be modified.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The scaled figure object.
+    ax : matplotlib.axes.Axes
+        The axes object, potentially modified.
+    scale : float
+        The modified scale value.
+    """
+
+    factor = globals.meta_network_base_font_size + len(
+        ax.patches) * globals.meta_network_font_scale_rate
+
+    suptitle_text = fig._suptitle
+    suptitle_text.set_fontsize(suptitle_text.get_fontsize() * factor)
+
+    for tick in ax.get_xticklabels():
+        tick.set_fontsize(tick.get_fontsize() * factor)
+
+    for tick in ax.get_yticklabels():
+        tick.set_fontsize(tick.get_fontsize() * factor)
+
+    xlabel = ax.xaxis.label
+    ylabel = ax.yaxis.label
+    xlabel.set_fontsize(xlabel.get_fontsize() * factor)
+    ylabel.set_fontsize(ylabel.get_fontsize() * factor)
+
+    legend = ax.get_legend()
+    for text in legend.get_texts():
+        text.set_fontsize(text.get_fontsize() * factor)
+
+    fig.tight_layout(pad=3.5)
+    new_bottom = fig.subplotpars.bottom * globals.meta_network_increase_padding_rate
+    fig.subplots_adjust(bottom=new_bottom)
+
+    # scale is to adjust size of Watermark, decreased here with increased number of networks.
+    watermark_scale -= len(ax.patches) * 0.001
+
+    return fig, ax, watermark_scale
+
+
 #$$
 class ClusteredBoxPlot:
     """
@@ -2089,15 +2171,16 @@ class ClusteredBoxPlot:
             except AttributeError:
                 pass
 
-        add_logo_to_figure(fig = _fig,
-                        logo_path = globals.watermark_logo_pth,
-                        position = globals.watermark_logo_position,
-                        offset = globals.watermark_logo_offset_comp_plots,
-                        scale = globals.watermark_logo_scale,
-                        )
+        add_logo_to_figure(
+            fig=_fig,
+            logo_path=globals.watermark_logo_pth,
+            position=globals.watermark_logo_position,
+            offset=globals.watermark_logo_offset_comp_plots,
+            scale=globals.watermark_logo_scale,
+        )
 
         return ClusteredBoxPlotContainer(fig=_fig,
-                                        ax_box=ax_box,
-                                        ax_median=ax_median,
-                                        ax_iqr=ax_iqr,
-                                        ax_n=ax_n)
+                                         ax_box=ax_box,
+                                         ax_median=ax_median,
+                                         ax_iqr=ax_iqr,
+                                         ax_n=ax_n)

--- a/tests/test_plot_all.py
+++ b/tests/test_plot_all.py
@@ -50,7 +50,7 @@ def test_plot_all(plotdir):
     )
 
     for tswp in temporal_sub_windows_present:
-        assert len(os.listdir(os.path.join(plotdir, tswp))) == 60
+        assert len(os.listdir(os.path.join(plotdir, tswp))) == 71
         assert all(os.path.splitext(file)[1] in [".png", ".csv"] for file in os.listdir(os.path.join(plotdir, tswp))), \
             "Not all files have been saved as .png or .csv"
 


### PR DESCRIPTION
- Figure size, font sizes and watermark are dependent on the number of networks.
- Metadata plots for the network category therefore received its own formatting
- The idea was to be more or less consistent with the layout and font-sizes of other metadata plots

Plotting examples below:

This is I believe the largest plot that can currently be produced with the current framework using ISMN v. ERA:
![bulk_boxplot_BIAS_metadata_network](https://github.com/user-attachments/assets/5c4cb45a-78e2-43ad-a4a3-99ae6eb6400e)



This is an even larger one produced with setting boxplot_min_samples to 1 (default is 5, y-labels are reformatted to one row), reflecting situation when more networks are added to ISMN in the future:
![bulk_boxplot_RMSD_metadata_network](https://github.com/user-attachments/assets/3c4e11a7-9a2c-41da-8084-02f3070e137c)



And this is an example when there are just 3 networks
![bulk_boxplot_mse_bias_metadata_network](https://github.com/user-attachments/assets/88e7aa9a-6e3b-4bdd-9803-74c75fd24ca9)
