### PR TITLE
Switch to coveralls GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,15 +90,13 @@ jobs:
     name: Submit Coveralls 👚
     needs: build
     runs-on: ubuntu-latest
-    container: python:3-slim
     steps:
       - name: Finalize Coveralls Parallel Build
-        run: |
-          pip3 install --upgrade coveralls
-          coveralls --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_SERVICE_NAME: github-actions
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+          coverage-reporter-version: v0.6.15
 
   publish-pypi-package:
     name: Publish PyPI 🚀

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-          coverage-reporter-version: v0.6.15
+        continue-on-error: true
 
   publish-pypi-package:
     name: Publish PyPI 🚀


### PR DESCRIPTION
Change coveralls ci approach and pin coverage-reporter-version because of frequent upload problems to coveralls (see https://github.com/coverallsapp/coverage-reporter/issues/180)